### PR TITLE
Add hostname config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Now that you have Mopidy up and running, let's setup up Apollo as our Frontend f
         var config = {
           development: {
             server: {
+              host: "localhost",
               port: 3000,
             },
             "twitter_callback":"http://localhost:3000/auth/twitter/callback",

--- a/apollo.js
+++ b/apollo.js
@@ -16,6 +16,7 @@ var server = http.createServer(app);
 
 
 // Configure server
+app.set('hostname', config.server.host);
 app.set('port', config.server.port);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
@@ -38,7 +39,7 @@ app.use(function (req, res) {
 app.use(express.errorHandler());
 
 
-server.listen(app.get('port'), function(){
+server.listen(app.get('port'), app.get('hostname'), function(){
   console.log('Express server listening on port ' + app.get('port'));
   routes(app,auth,server);
 });


### PR DESCRIPTION
Added a hostname option in config.js and apollo.js.
server.listen() defaults to 0.0.0.0 (any address), which is not optimal. Also, it adds flexibility for network setup.
